### PR TITLE
Proper logging, refactored the output for Acid::Executor.run()

### DIFF
--- a/lib/acid/config.rb
+++ b/lib/acid/config.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'logger'
 require 'helpers/os'
 
 class Acid::Config
@@ -6,8 +7,7 @@ class Acid::Config
   def shell
     return @shell      if @shell
     return 'cmd /C'    if OS.windows? # TODO: is there any other (better) choice than cmd?
-    return 'bash -c'   if OS.linux? # Append -r for restricted bash (check bash(1) man page)
-    # TODO: OSX/darwin default shell?
+    return 'bash -c'   if OS.unix? # Append -r for restricted bash (check bash(1) man page)
     nil
   end
 
@@ -28,6 +28,7 @@ class Acid::Config
 
   # Parses the acid.yml file in the current directory
   def read(path)
+    Acid::LOG.log(Logger::DEBUG, "Reading config file at '#{path}'", 'Acid::Config') if Acid::LOG
     (YAML.load_file path).each { |name, val| instance_variable_set("@#{name}", val) }
   end
 end

--- a/lib/acid/executor.rb
+++ b/lib/acid/executor.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'colorize'
+require 'logger'
 
 class Acid::Executor
   # Creates a new Acid::Executor with the provided environment and shell
@@ -10,6 +11,7 @@ class Acid::Executor
 
   # Creates a thread that pipes streams until killed
   def capture(stream_from, stream_to, &filter)
+    Acid::LOG.log(Logger::DEBUG, 'Starting capture thread', 'Acid::Executor') if Acid::LOG
     Thread.new {
       while true # TODO: Using waitpid to check if the thread is alive kills it, but just looping like this is dangerous
         r = stream_from.read
@@ -22,17 +24,17 @@ class Acid::Executor
   end
 
   # Executes a single command
-  def run(command)
-    puts "Running '#{command}'...".yellow
+  def run(command, output)
+    Acid::LOG.log(Logger::DEBUG, "Running '#{command}'...", 'Acid::Executor') if Acid::LOG
     # Capture stdout and stderr separately http://ruby-doc.org/stdlib-2.1.4/libdoc/open3/rdoc/Open3.html#method-c-popen3
     Open3.popen3(@env, [@shell, '"' + command.gsub("'", %q(\\\')).gsub('"', %q(\\\")) + '"'].join(' ')) { |stdin, stdout, stderr, wait_thr|
-      puts "Started using #{@shell.split(' ')[0]}, PID is #{wait_thr.pid}".green; puts
+      Acid::LOG.log(Logger::DEBUG, "Using #{@shell.split(' ')[0]}, PID is #{wait_thr.pid}", 'Acid::Executor') if Acid::LOG
       stdin.close # We don't need it and the process might wait for it to close if it needs input
       # Loop while the child process is alive (nonblocking) http://stackoverflow.com/a/14381862/2386865
       begin
         # Print stdout and stderr to console
-        thr_out = self.capture(stdout, $stdout)
-        thr_err = self.capture(stderr, $stdout) { |text| text.red }
+        thr_out = self.capture(stdout, output)
+        thr_err = self.capture(stderr, output) { |text| text.red }
         wait_thr.join
         thr_out.kill; thr_err.kill
       rescue Errno::ECHILD, Errno::EINVAL
@@ -40,10 +42,10 @@ class Acid::Executor
       end
       val = wait_thr.value
       if val != nil
-        puts; puts "Exited with code #{val.exitstatus}".green; puts
+        Acid::LOG.log(Logger::DEBUG, "Exited with code #{val.exitstatus}", 'Acid::Executor') if Acid::LOG
         return val.exitstatus
       else
-        puts; puts 'Process vanished, exit code unavailable'.yellow; puts
+        Acid::LOG.log(Logger::ERROR, 'Process vanished, exit code unavailable', 'Acid::Executor') if Acid::LOG
         return -1
       end
     }


### PR DESCRIPTION
Now Acid::Executor requires a stream.
